### PR TITLE
fast id generation for all slot types

### DIFF
--- a/lib/yt_search/channel_slot.ex
+++ b/lib/yt_search/channel_slot.ex
@@ -9,7 +9,7 @@ defmodule YtSearch.ChannelSlot do
   @primary_key {:id, :integer, autogenerate: false}
 
   # 20 times to retry
-  def max_id_retries, do: 15
+  def max_id_retries, do: 1
   # 2 hours
   def ttl, do: 2 * 60 * 60
   # this number must be synced with the world build

--- a/lib/yt_search/playlist_slot.ex
+++ b/lib/yt_search/playlist_slot.ex
@@ -8,8 +8,8 @@ defmodule YtSearch.PlaylistSlot do
   @type t :: %__MODULE__{}
   @primary_key {:id, :integer, autogenerate: false}
 
-  # 20 times to retry
-  def max_id_retries, do: 20
+  # 1 times to retry
+  def max_id_retries, do: 1
   # 12 hours
   def ttl, do: 12 * 60 * 60
   # this number must be synced with the world build

--- a/lib/yt_search/search_slot.ex
+++ b/lib/yt_search/search_slot.ex
@@ -14,7 +14,7 @@ defmodule YtSearch.SearchSlot do
   @primary_key {:id, :integer, autogenerate: false}
 
   # 20 times to retry
-  def max_id_retries, do: 20
+  def max_id_retries, do: 2
   # 20 minutes
   def ttl, do: 20 * 60
   # this number must be synced with the world build

--- a/lib/yt_search/slot.ex
+++ b/lib/yt_search/slot.ex
@@ -80,7 +80,7 @@ defmodule YtSearch.Slot do
     end
   end
 
-  def max_id_retries, do: 15
+  def max_id_retries, do: 2
   # 10 minutes to 12 hours
   # defaults to 1h for slots without duration
   def min_ttl, do: 10 * 60

--- a/lib/yt_search_web/router.ex
+++ b/lib/yt_search_web/router.ex
@@ -17,6 +17,7 @@ defmodule YtSearchWeb.Router do
     get("/sr/:slot_id", SlotController, :fetch_redirect)
     get("/thumbnail_atlas/:search_slot_id", AtlasController, :fetch)
     get("/hello", HelloController, :hello)
+    get("/hello/:build_number", HelloController, :hello)
   end
 
   # smaller url version of the api, this is a bodge for

--- a/priv/repo/migrations/20230827190225_add_unixepoch_indexes_on_all_slots.exs
+++ b/priv/repo/migrations/20230827190225_add_unixepoch_indexes_on_all_slots.exs
@@ -1,0 +1,9 @@
+defmodule YtSearch.Repo.Migrations.AddUnixepochIndexesOnAllSlots do
+  use Ecto.Migration
+
+  def change do
+    create index(:channel_slots, ["unixepoch(inserted_at)"])
+    create index(:search_slots, ["unixepoch(inserted_at)"])
+    create index(:playlist_slots, ["unixepoch(inserted_at)"])
+  end
+end

--- a/priv/repo/migrations/20230827194939_add_youtube_id_index_on_channel_slots.exs
+++ b/priv/repo/migrations/20230827194939_add_youtube_id_index_on_channel_slots.exs
@@ -1,0 +1,7 @@
+defmodule YtSearch.Repo.Migrations.AddYoutubeIdIndexOnChannelSlots do
+  use Ecto.Migration
+
+  def change do
+    create index(:channel_slots, [:youtube_id])
+  end
+end


### PR DESCRIPTION
- [x] write tests
- [x] add index on `unixepoch(inserted_at)`
- [x] pray that it works
- [x] if it works, ship it
- [x] ~~if not, do the `inserted_at_v2` hack that i made for video slots~~ IT WORKS HAHAHAHAH YES IT WORKSS FUCK YES IT WORKS