### PR TITLE
make thumbnail blocking via ETS

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -156,7 +156,7 @@ config :yt_search, YtSearch.Constants,
   enable_periodic_janitors: true,
   redirect_to_googlevideo?: true,
   extract_cta?: true,
-  thumbnails_in_search_page: 20
+  thumbnails_in_search_page: 32
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/lib/yt_search/application.ex
+++ b/lib/yt_search/application.ex
@@ -88,6 +88,7 @@ defmodule YtSearch.Application do
         YtSearch.CounterServer,
         {DynamicSupervisor, strategy: :one_for_one, name: YtSearch.MetadataSupervisor},
         {Task.Supervisor, strategy: :one_for_one, name: YtSearch.ThumbnailSupervisor},
+        YtSearch.Youtube.Thumbnail.Monitor,
         {Registry, keys: :unique, name: YtSearch.MetadataWorkers},
         {Registry, keys: :unique, name: YtSearch.MetadataExtractors},
         {Task.Supervisor, strategy: :one_for_one, name: YtSearch.SlotMetadataSupervisor}

--- a/lib/yt_search/application.ex
+++ b/lib/yt_search/application.ex
@@ -48,6 +48,9 @@ defmodule YtSearch.Application do
     File.mkdir_p!("thumbnails")
     File.mkdir_p!("subtitles")
 
+    # ETS table to track thumbnail download tasks
+    :ets.new(:thumbnail_tasks, [:set, :public, :named_table, read_concurrency: true])
+
     children_before_repos =
       [
         # Start the Telemetry supervisor

--- a/lib/yt_search/thumbnail_atlas.ex
+++ b/lib/yt_search/thumbnail_atlas.ex
@@ -79,17 +79,22 @@ defmodule YtSearch.Thumbnail.Atlas do
         if slot != nil do
           # First, check if there's a pending download task
           case :ets.lookup(:thumbnail_tasks, slot.youtube_id) do
-            [{_id, task}] ->
+            [{_id, pid}] when is_pid(pid) ->
               # Task is running or queued, wait for it with timeout
-              case Task.yield(task, 10_000) || Task.shutdown(task) do
-                {:ok, _result} ->
-                  :ok
+              if Process.alive?(pid) do
+                ref = Process.monitor(pid)
 
-                nil ->
-                  Logger.warning("Thumbnail task timeout for #{slot.youtube_id}")
+                receive do
+                  {:DOWN, ^ref, :process, ^pid, _reason} ->
+                    :ok
+                after
+                  10_000 ->
+                    Process.demonitor(ref, [:flush])
+                    Logger.warning("Thumbnail task timeout for #{slot.youtube_id}")
+                end
               end
 
-            [] ->
+            _ ->
               # No task, proceed normally
               :ok
           end

--- a/lib/yt_search/thumbnail_atlas.ex
+++ b/lib/yt_search/thumbnail_atlas.ex
@@ -71,6 +71,9 @@ defmodule YtSearch.Thumbnail.Atlas do
   defp internal_assemble(slots) do
     YtSearch.Youtube.Thumbnail.TaskCounter.inc_atlas(:assemble)
 
+    # make all atlases +1sec to see if thumbnail failure rates drop
+    Process.sleep(1000)
+
     thumbnail_paths =
       slots
       |> Enum.map(fn slot ->

--- a/lib/yt_search/thumbnail_atlas.ex
+++ b/lib/yt_search/thumbnail_atlas.ex
@@ -69,6 +69,8 @@ defmodule YtSearch.Thumbnail.Atlas do
   end
 
   defp internal_assemble(slots) do
+    YtSearch.Youtube.Thumbnail.TaskCounter.inc_atlas(:assemble)
+
     thumbnail_paths =
       slots
       |> Enum.map(fn slot ->
@@ -78,17 +80,22 @@ defmodule YtSearch.Thumbnail.Atlas do
 
         if slot != nil do
           # First, check if there's a pending download task
+          YtSearch.Youtube.Thumbnail.TaskCounter.inc_atlas(:ets_check)
+
           case :ets.lookup(:thumbnail_tasks, slot.youtube_id) do
             [{_id, pid}] when is_pid(pid) ->
               # Task is running or queued, wait for it with timeout
               if Process.alive?(pid) do
+                YtSearch.Youtube.Thumbnail.TaskCounter.inc_atlas(:ets_alive)
                 ref = Process.monitor(pid)
 
                 receive do
                   {:DOWN, ^ref, :process, ^pid, _reason} ->
+                    YtSearch.Youtube.Thumbnail.TaskCounter.inc_atlas(:ets_monitored)
                     :ok
                 after
                   10_000 ->
+                    YtSearch.Youtube.Thumbnail.TaskCounter.inc_atlas(:ets_timeout)
                     Process.demonitor(ref, [:flush])
                     Logger.warning("Thumbnail task timeout for #{slot.youtube_id}")
                 end
@@ -96,6 +103,7 @@ defmodule YtSearch.Thumbnail.Atlas do
 
             _ ->
               # No task, proceed normally
+              YtSearch.Youtube.Thumbnail.TaskCounter.inc_atlas(:ets_none)
               :ok
           end
 

--- a/lib/yt_search/thumbnail_atlas.ex
+++ b/lib/yt_search/thumbnail_atlas.ex
@@ -79,6 +79,16 @@ defmodule YtSearch.Thumbnail.Atlas do
         # them all before assembling atlas
 
         if slot != nil do
+          thumb1 =
+            slot.youtube_id
+            |> Thumbnail.fetch()
+
+          if thumb1 == nil do
+            YtSearch.Youtube.Thumbnail.TaskCounter.inc_atlas(:thumb1_nil)
+          else
+            YtSearch.Youtube.Thumbnail.TaskCounter.inc_atlas(:thumb1_nonil)
+          end
+
           # First, check if there's a pending download task
           YtSearch.Youtube.Thumbnail.TaskCounter.inc_atlas(:ets_check)
 

--- a/lib/yt_search/thumbnail_atlas.ex
+++ b/lib/yt_search/thumbnail_atlas.ex
@@ -77,6 +77,24 @@ defmodule YtSearch.Thumbnail.Atlas do
         # them all before assembling atlas
 
         if slot != nil do
+          # First, check if there's a pending download task
+          case :ets.lookup(:thumbnail_tasks, slot.youtube_id) do
+            [{_id, task}] ->
+              # Task is running or queued, wait for it with timeout
+              case Task.yield(task, 10_000) || Task.shutdown(task) do
+                {:ok, _result} ->
+                  :ok
+
+                nil ->
+                  Logger.warning("Thumbnail task timeout for #{slot.youtube_id}")
+              end
+
+            [] ->
+              # No task, proceed normally
+              :ok
+          end
+
+          # Now acquire mutex and fetch as before
           Mutex.under(ThumbnailMutex, slot.youtube_id, fn ->
             thumb =
               slot.youtube_id

--- a/lib/yt_search/thumbnail_atlas.ex
+++ b/lib/yt_search/thumbnail_atlas.ex
@@ -71,9 +71,6 @@ defmodule YtSearch.Thumbnail.Atlas do
   defp internal_assemble(slots) do
     YtSearch.Youtube.Thumbnail.TaskCounter.inc_atlas(:assemble)
 
-    # make all atlases +1sec to see if thumbnail failure rates drop
-    Process.sleep(1000)
-
     thumbnail_paths =
       slots
       |> Enum.map(fn slot ->

--- a/lib/yt_search/youtube_thumbnail.ex
+++ b/lib/yt_search/youtube_thumbnail.ex
@@ -18,6 +18,26 @@ defmodule YtSearch.Youtube.Thumbnail do
         name: :yts_thumbnail_task_total,
         help: "Thumbnail tasks"
       )
+
+      Counter.declare(
+        name: :yts_thumbnail_task_spawns,
+        help: "Thumbnail task spawns"
+      )
+
+      Counter.declare(
+        name: :yts_thumbnail_task_checks,
+        help: "Thumbnail task checks"
+      )
+
+      Counter.declare(
+        name: :yts_thumbnail_task_execs,
+        help: "Thumbnail task execs"
+      )
+
+      Counter.declare(
+        name: :yts_thumbnail_task_finish,
+        help: "Thumbnail task finishs"
+      )
     end
 
     def inc(status) do
@@ -28,6 +48,22 @@ defmodule YtSearch.Youtube.Thumbnail do
         labels: [to_string(status)]
       )
     end
+
+    def inc_check() do
+      Counter.inc(name: :yts_thumbnail_task_checks)
+    end
+
+    def inc_spawn() do
+      Counter.inc(name: :yts_thumbnail_task_spawns)
+    end
+
+    def inc_exec() do
+      Counter.inc(name: :yts_thumbnail_task_execs)
+    end
+
+    def inc_finish() do
+      Counter.inc(name: :yts_thumbnail_task_finish)
+    end
   end
 
   defmodule ThumbnailMetadata do
@@ -36,9 +72,15 @@ defmodule YtSearch.Youtube.Thumbnail do
   end
 
   def fetch_piped_in_background(youtube_id, data, opts) do
+    TaskCounter.inc_check()
+
     if data["thumbnail"] != nil do
+      TaskCounter.inc_spawn()
+
       task =
         Task.Supervisor.async(YtSearch.ThumbnailSupervisor, fn ->
+          TaskCounter.inc_exec()
+
           try do
             maybe_download_thumbnail(
               youtube_id,
@@ -46,6 +88,7 @@ defmodule YtSearch.Youtube.Thumbnail do
               opts
             )
           after
+            TaskCounter.inc_finish()
             # Clean up task ref when done
             :ets.delete(:thumbnail_tasks, youtube_id)
           end

--- a/lib/yt_search/youtube_thumbnail.ex
+++ b/lib/yt_search/youtube_thumbnail.ex
@@ -265,39 +265,46 @@ defmodule YtSearch.Youtube.Thumbnail do
         File.rm(temporary_path)
         {:ok, Thumbnail.insert(youtube_id, content_type, final_body, opts)}
       else
-        input_image = Image.from_binary!(body)
+        YtSearch.MetadataExtractor.Worker.TaskLatency.register(:thumbnail_process, fn ->
+          input_image = Image.from_binary!(body)
 
-        {image_width, image_height} = {
-          input_image |> Image.width(),
-          input_image |> Image.height()
-        }
+          {image_width, image_height} = {
+            input_image |> Image.width(),
+            input_image |> Image.height()
+          }
 
-        {target_width, target_height} = target_dimensions(image_width, image_height)
+          {target_width, target_height} = target_dimensions(image_width, image_height)
 
-        input_image
-        |> Image.add_alpha(:transparent)
-        |> then(fn
-          {:ok, image} ->
-            image
+          input_image
+          |> Image.add_alpha(:transparent)
+          |> then(fn
+            {:ok, image} ->
+              image
 
-          {:error, "Image already has an alpha band"} ->
-            input_image
+            {:error, "Image already has an alpha band"} ->
+              input_image
 
-          {:error, err} ->
-            raise err
+            {:error, err} ->
+              raise err
+          end)
+          |> Image.thumbnail!(target_width, height: target_height, resize: :force)
+          |> Image.embed!(128, 128, background_transparency: 0, x: :center, y: :center)
+          |> Image.write!(
+            youtube_id
+            |> Thumbnail.path_for()
+            |> File.stream!(),
+            # use lossless webp as an exchange in storage vs unecessary CPU time
+            suffix: ".webp",
+            effort: 1
+          )
         end)
-        |> Image.thumbnail!(target_width, height: target_height, resize: :force)
-        |> Image.embed!(128, 128, background_transparency: 0, x: :center, y: :center)
-        |> Image.write!(
-          youtube_id
-          |> Thumbnail.path_for()
-          |> File.stream!(),
-          # use lossless webp as an exchange in storage vs unecessary CPU time
-          suffix: ".webp",
-          effort: 1
-        )
 
-        {:ok, Thumbnail.insert(youtube_id, content_type, opts)}
+        t =
+          YtSearch.MetadataExtractor.Worker.TaskLatency.register(:thumbnail_database, fn ->
+            Thumbnail.insert(youtube_id, content_type, opts)
+          end)
+
+        {:ok, t}
       end
     else
       Logger.error(

--- a/lib/yt_search/youtube_thumbnail.ex
+++ b/lib/yt_search/youtube_thumbnail.ex
@@ -38,6 +38,21 @@ defmodule YtSearch.Youtube.Thumbnail do
         name: :yts_thumbnail_task_finish,
         help: "Thumbnail task finishs"
       )
+
+      Counter.declare(
+        name: :yts_thumbnail_task_inner_checks,
+        help: "Thumbnail task inner checks"
+      )
+
+      Counter.declare(
+        name: :yts_thumbnail_task_inner_downloads,
+        help: "Thumbnail task inner downloads"
+      )
+
+      Counter.declare(
+        name: :yts_thumbnail_task_inner_inner_downloads,
+        help: "Thumbnail task inner inner downloads"
+      )
     end
 
     def inc(status) do
@@ -63,6 +78,18 @@ defmodule YtSearch.Youtube.Thumbnail do
 
     def inc_finish() do
       Counter.inc(name: :yts_thumbnail_task_finish)
+    end
+
+    def inc_inner_check() do
+      Counter.inc(name: :yts_thumbnail_task_inner_checks)
+    end
+
+    def inc_inner_download() do
+      Counter.inc(name: :yts_thumbnail_task_inner_downloads)
+    end
+
+    def inc_inner_inner_download() do
+      Counter.inc(name: :yts_thumbnail_task_inner_inner_downloads)
     end
   end
 
@@ -120,6 +147,7 @@ defmodule YtSearch.Youtube.Thumbnail do
 
   @spec maybe_download_thumbnail(String.t(), String.t(), Keyword.t()) :: Thumbnail.t()
   def maybe_download_thumbnail(id, url, opts) do
+    TaskCounter.inc_inner_check()
     maybe_metadata = Thumbnail.fetch(id)
     maybe_filesize = filesize_for(id)
     should_download? = maybe_metadata == nil or maybe_filesize == 0
@@ -133,7 +161,14 @@ defmodule YtSearch.Youtube.Thumbnail do
   end
 
   def mutexed_download_thumbnail(id, url, opts) do
+    start_ts = System.monotonic_time(:millisecond)
+
     Mutex.under(ThumbnailMutex, id, fn ->
+      end_ts = System.monotonic_time(:millisecond)
+      latency = end_ts - start_ts
+      YtSearch.MetadataExtractor.Worker.TaskLatency.register(:thumbnail_mutex, latency)
+
+      TaskCounter.inc_inner_download()
       # refetch to prevent double fetch
       case Thumbnail.fetch(id) do
         nil ->
@@ -148,6 +183,8 @@ defmodule YtSearch.Youtube.Thumbnail do
   @mogrify false
 
   defp do_download_thumbnail(youtube_id, url, opts) do
+    TaskCounter.inc_inner_inner_download()
+
     if filesize_for(youtube_id) > 0 do
       # if it already exists, insert the metadata entry (as to be in this function,
       # the db entry would be currently missing)
@@ -194,12 +231,14 @@ defmodule YtSearch.Youtube.Thumbnail do
 
     # youtube channels give urls without scheme for some reason
     {:ok, response} =
-      if String.starts_with?(url, "//") do
-        "https:#{url}"
-      else
-        url
-      end
-      |> Tesla.get()
+      YtSearch.MetadataExtractor.Worker.TaskLatency.register(:thumbnail_download, fn ->
+        if String.starts_with?(url, "//") do
+          "https:#{url}"
+        else
+          url
+        end
+        |> Tesla.get()
+      end)
 
     if response.status == 200 do
       content_type = Tesla.get_header(response, "content-type")

--- a/lib/yt_search/youtube_thumbnail.ex
+++ b/lib/yt_search/youtube_thumbnail.ex
@@ -15,6 +15,12 @@ defmodule YtSearch.Youtube.Thumbnail do
       )
 
       Counter.declare(
+        name: :yts_atlas_count,
+        help: "atlas stuff",
+        labels: [:status]
+      )
+
+      Counter.declare(
         name: :yts_thumbnail_task_total,
         help: "Thumbnail tasks"
       )
@@ -60,6 +66,13 @@ defmodule YtSearch.Youtube.Thumbnail do
 
       Counter.inc(
         name: :yts_thumbnail_task_results,
+        labels: [to_string(status)]
+      )
+    end
+
+    def inc_atlas(status) do
+      Counter.inc(
+        name: :yts_atlas_count,
         labels: [to_string(status)]
       )
     end

--- a/lib/yt_search/youtube_thumbnail.ex
+++ b/lib/yt_search/youtube_thumbnail.ex
@@ -166,6 +166,8 @@ defmodule YtSearch.Youtube.Thumbnail do
 
       task =
         Task.Supervisor.async(YtSearch.ThumbnailSupervisor, fn ->
+          :ets.insert(:thumbnail_tasks, {youtube_id, self()})
+
           TaskCounter.inc_exec()
 
           try do
@@ -180,9 +182,6 @@ defmodule YtSearch.Youtube.Thumbnail do
             :ets.delete(:thumbnail_tasks, youtube_id)
           end
         end)
-
-      # Store task PID so atlas can await it (store PID not Task struct to allow cross-process monitoring)
-      :ets.insert(:thumbnail_tasks, {youtube_id, task.pid})
 
       # Monitor the task to track exit reasons
       Monitor.add(task.pid)

--- a/lib/yt_search/youtube_thumbnail.ex
+++ b/lib/yt_search/youtube_thumbnail.ex
@@ -218,6 +218,8 @@ defmodule YtSearch.Youtube.Thumbnail do
     if should_download? do
       mutexed_download_thumbnail(id, url, opts)
     else
+      TaskCounter.inc(:already_exists)
+
       maybe_metadata
       |> SlotUtilities.refresh_expiration(opts)
     end

--- a/lib/yt_search/youtube_thumbnail.ex
+++ b/lib/yt_search/youtube_thumbnail.ex
@@ -59,6 +59,12 @@ defmodule YtSearch.Youtube.Thumbnail do
         name: :yts_thumbnail_task_inner_inner_downloads,
         help: "Thumbnail task inner inner downloads"
       )
+
+      Counter.declare(
+        name: :yts_thumb_mon,
+        help: "Thumbnail task monitor exit reasons",
+        labels: [:reason]
+      )
     end
 
     def inc(status) do
@@ -104,11 +110,52 @@ defmodule YtSearch.Youtube.Thumbnail do
     def inc_inner_inner_download() do
       Counter.inc(name: :yts_thumbnail_task_inner_inner_downloads)
     end
+
+    def inc_monitor(reason) do
+      Counter.inc(
+        name: :yts_thumb_mon,
+        labels: [to_string(reason)]
+      )
+    end
   end
 
   defmodule ThumbnailMetadata do
     @derive Jason.Encoder
     defstruct [:aspect_ratio]
+  end
+
+  defmodule Monitor do
+    use GenServer
+
+    def start_link(_opts) do
+      GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+    end
+
+    @doc """
+    Add a PID to be monitored. When the process exits, its exit reason
+    will be recorded via TaskCounter.inc/1
+    """
+    def add(pid) when is_pid(pid) do
+      GenServer.cast(__MODULE__, {:monitor, pid})
+    end
+
+    @impl true
+    def init(_) do
+      {:ok, %{}}
+    end
+
+    @impl true
+    def handle_cast({:monitor, pid}, state) do
+      ref = Process.monitor(pid)
+      {:noreply, Map.put(state, ref, pid)}
+    end
+
+    @impl true
+    def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
+      # Record the exit reason to TaskCounter
+      TaskCounter.inc_monitor(reason)
+      {:noreply, Map.delete(state, ref)}
+    end
   end
 
   def fetch_piped_in_background(youtube_id, data, opts) do
@@ -136,6 +183,9 @@ defmodule YtSearch.Youtube.Thumbnail do
 
       # Store task PID so atlas can await it (store PID not Task struct to allow cross-process monitoring)
       :ets.insert(:thumbnail_tasks, {youtube_id, task.pid})
+
+      # Monitor the task to track exit reasons
+      Monitor.add(task.pid)
 
       # NOTE: this is a fake ratio because we now do 1:1 ratio with alpha on atlas
       # UPGRADE: aspect_ratio is not used on /a/2

--- a/lib/yt_search/youtube_thumbnail.ex
+++ b/lib/yt_search/youtube_thumbnail.ex
@@ -229,18 +229,25 @@ defmodule YtSearch.Youtube.Thumbnail do
     start_ts = System.monotonic_time(:millisecond)
 
     Mutex.under(ThumbnailMutex, id, fn ->
-      end_ts = System.monotonic_time(:millisecond)
-      latency = end_ts - start_ts
-      YtSearch.MetadataExtractor.Worker.TaskLatency.register(:thumbnail_mutex, latency)
+      try do
+        end_ts = System.monotonic_time(:millisecond)
+        latency = end_ts - start_ts
+        YtSearch.MetadataExtractor.Worker.TaskLatency.register(:thumbnail_mutex, latency)
 
-      TaskCounter.inc_inner_download()
-      # refetch to prevent double fetch
-      case Thumbnail.fetch(id) do
-        nil ->
-          do_download_thumbnail(id, url, opts)
+        TaskCounter.inc_inner_download()
+        # refetch to prevent double fetch
+        case Thumbnail.fetch(id) do
+          nil ->
+            do_download_thumbnail(id, url, opts)
 
-        thumb ->
-          thumb
+          thumb ->
+            thumb
+        end
+      rescue
+        e ->
+          Logger.error(Exception.format(:error, e, __STACKTRACE__))
+          TaskCounter.inc(:predownload_exception)
+          reraise e, __STACKTRACE__
       end
     end)
   end

--- a/lib/yt_search/youtube_thumbnail.ex
+++ b/lib/yt_search/youtube_thumbnail.ex
@@ -112,15 +112,22 @@ defmodule YtSearch.Youtube.Thumbnail do
       {:ok, Thumbnail.insert(youtube_id, "image/webp", opts)}
     else
       YtSearch.MetadataExtractor.Worker.TaskLatency.register(:thumbnail, fn ->
-        result = really_do_download_thumbnail(youtube_id, url, opts)
+        try do
+          result = really_do_download_thumbnail(youtube_id, url, opts)
 
-        case result do
-          {:ok, _} -> TaskCounter.inc(:success)
-          {:error, {:http_response, status, _, _}} -> TaskCounter.inc("error_http_#{status}")
-          {:error, _} -> TaskCounter.inc(:error_other)
+          case result do
+            {:ok, _} -> TaskCounter.inc(:success)
+            {:error, {:http_response, status, _, _}} -> TaskCounter.inc("error_http_#{status}")
+            {:error, _} -> TaskCounter.inc(:error_other)
+          end
+
+          result
+        rescue
+          e ->
+            Logger.error(Exception.format(:error, e, __STACKTRACE__))
+            TaskCounter.inc(:exception)
+            reraise e, __STACKTRACE__
         end
-
-        result
       end)
     end
   end

--- a/lib/yt_search/youtube_thumbnail.ex
+++ b/lib/yt_search/youtube_thumbnail.ex
@@ -51,8 +51,8 @@ defmodule YtSearch.Youtube.Thumbnail do
           end
         end)
 
-      # Store task ref so atlas can await it
-      :ets.insert(:thumbnail_tasks, {youtube_id, task})
+      # Store task PID so atlas can await it (store PID not Task struct to allow cross-process monitoring)
+      :ets.insert(:thumbnail_tasks, {youtube_id, task.pid})
 
       # NOTE: this is a fake ratio because we now do 1:1 ratio with alpha on atlas
       # UPGRADE: aspect_ratio is not used on /a/2

--- a/lib/yt_search/youtube_thumbnail.ex
+++ b/lib/yt_search/youtube_thumbnail.ex
@@ -37,13 +37,22 @@ defmodule YtSearch.Youtube.Thumbnail do
 
   def fetch_piped_in_background(youtube_id, data, opts) do
     if data["thumbnail"] != nil do
-      Task.Supervisor.async(YtSearch.ThumbnailSupervisor, fn ->
-        maybe_download_thumbnail(
-          youtube_id,
-          data["thumbnail"] |> YtSearch.Youtube.unproxied_piped_url(),
-          opts
-        )
-      end)
+      task =
+        Task.Supervisor.async(YtSearch.ThumbnailSupervisor, fn ->
+          try do
+            maybe_download_thumbnail(
+              youtube_id,
+              data["thumbnail"] |> YtSearch.Youtube.unproxied_piped_url(),
+              opts
+            )
+          after
+            # Clean up task ref when done
+            :ets.delete(:thumbnail_tasks, youtube_id)
+          end
+        end)
+
+      # Store task ref so atlas can await it
+      :ets.insert(:thumbnail_tasks, {youtube_id, task})
 
       # NOTE: this is a fake ratio because we now do 1:1 ratio with alpha on atlas
       # UPGRADE: aspect_ratio is not used on /a/2

--- a/lib/yt_search_web/playlist.ex
+++ b/lib/yt_search_web/playlist.ex
@@ -52,6 +52,7 @@ defmodule YtSearchWeb.Playlist do
         Application.get_env(:yt_search, YtSearch.Constants)[:thumbnails_in_search_page]
 
       youtube_id = data["url"] |> youtube_id_from_url
+
       thumbnail_metadata =
         if index < thumbnail_limit do
           Youtube.Thumbnail.fetch_piped_in_background(youtube_id, data, opts)

--- a/lib/yt_search_web/playlist.ex
+++ b/lib/yt_search_web/playlist.ex
@@ -68,6 +68,9 @@ defmodule YtSearchWeb.Playlist do
       end)
     end)
     |> then(fn result_list ->
+      # make all searches +1sec to see if thumbnail failure rates drop
+      Process.sleep(1000)
+
       if nextpage? do
         %{results: result_list, nextpage: nextpage_data, type: json.type, title: json.title}
       else

--- a/lib/yt_search_web/playlist.ex
+++ b/lib/yt_search_web/playlist.ex
@@ -68,9 +68,6 @@ defmodule YtSearchWeb.Playlist do
       end)
     end)
     |> then(fn result_list ->
-      # make all searches +1sec to see if thumbnail failure rates drop
-      Process.sleep(1000)
-
       if nextpage? do
         %{results: result_list, nextpage: nextpage_data, type: json.type, title: json.title}
       else


### PR DESCRIPTION
store task pid on ets and then wait on it via a monitor

also fixes the bug where thumbnails would be missing from the later results of a search/channel/playlist/etc